### PR TITLE
Update X handle from @notjoswayski to @josevalerio

### DIFF
--- a/services/web/app/routes/blog/ass.tsx
+++ b/services/web/app/routes/blog/ass.tsx
@@ -70,11 +70,11 @@ export default function SpareChangeRoundBlogPost() {
               </a>{" "}
               and{" "}
               <a
-                href="https://x.com/notjoswayski"
+                href="https://x.com/josevalerio"
                 target="_blank"
                 className="text-blue-500 hover:text-blue-700"
               >
-                @notjoswayski
+                @josevalerio
               </a>
               , we've been able to develop and launch ASS after months of
               rigorous testing with Fortune 500 companies who have reported

--- a/services/web/components/BlogListing.tsx
+++ b/services/web/components/BlogListing.tsx
@@ -23,7 +23,7 @@ const blogPosts = [
     date: "August 03, 2025",
     slug: "ass",
     excerpt:
-      "We've raised $21.97 from @AvgDatabaseCEO and @notjoswayski to build the future of Average Storage Service (ASS)",
+      "We've raised $21.97 from @AvgDatabaseCEO and @josevalerio to build the future of Average Storage Service (ASS)",
   },
   {
     title: `They asked us what we would do if we couldn't raise another round..`,

--- a/services/web/components/Footer.tsx
+++ b/services/web/components/Footer.tsx
@@ -23,13 +23,13 @@ export function Footer() {
           </Anchor>
           <Text size="sm" c="dimmed">•</Text>
           <Anchor 
-            href="https://x.com/notjoswayski" 
+            href="https://x.com/josevalerio" 
             target="_blank" 
             rel="noopener noreferrer"
             size="sm"
             className="hover:text-blue-500"
           >
-            @notjoswayski
+            @josevalerio
           </Anchor>
         </Group>
       </div>


### PR DESCRIPTION
## Summary
- Replace all `@notjoswayski` / `x.com/notjoswayski` references with `@josevalerio` / `x.com/josevalerio`
- Touches footer, ASS blog post, and blog listing excerpt

## Test plan
- [ ] Confirm footer link goes to https://x.com/josevalerio
- [ ] Confirm ASS blog post link and display text use @josevalerio
- [ ] Confirm blog listing excerpt shows @josevalerio