### PR TITLE
Fix testimonial X handles and keep avatars current

### DIFF
--- a/services/web/README.md
+++ b/services/web/README.md
@@ -11,8 +11,9 @@ Worker.
 
 The Worker runs first only for:
 
-- `/api/*`, currently used by `/api/gibs-key` as a thin proxy to the existing
-  Rust API.
+- `/api/*`, used by `/api/gibs-key` as a thin proxy to the existing Rust API
+  and by `/api/avatar/:handle` to resolve current X profile pictures for
+  testimonials (cached, with the stored snapshot as fallback).
 - `/status/incident-report-april-1-2026-control-plane-degradation`, which keeps
   the existing user-agent-dependent April Fools redirect while serving the
   prerendered incident page to link-preview bots.

--- a/services/web/app/avatar.ts
+++ b/services/web/app/avatar.ts
@@ -1,0 +1,79 @@
+import { testimonials, type Testimonial } from "./data/testimonials";
+
+export const AVATAR_PATH_PREFIX = "/api/avatar/";
+export const AVATAR_CACHE_TTL_SECONDS = 60 * 60 * 24;
+
+const FX_TWITTER_USER_URL = "https://api.fxtwitter.com";
+
+type CfAwareRequestInit = RequestInit & {
+  cf?: {
+    cacheEverything?: boolean;
+    cacheTtl?: number;
+  };
+};
+
+type FxTwitterUserResponse = {
+  user?: {
+    avatar_url?: string;
+  };
+};
+
+export function isXTestimonial(testimonial: Testimonial): boolean {
+  return testimonial.xeet.startsWith("https://x.com/");
+}
+
+export function testimonialAvatarSrc(testimonial: Testimonial): string {
+  if (!isXTestimonial(testimonial)) {
+    return testimonial.imageUrl;
+  }
+
+  return `${AVATAR_PATH_PREFIX}${encodeURIComponent(testimonial.handle)}`;
+}
+
+export function findTestimonialByHandle(
+  handle: string,
+): Testimonial | undefined {
+  const normalizedHandle = handle.toLowerCase();
+  return testimonials.find(
+    (testimonial) => testimonial.handle.toLowerCase() === normalizedHandle,
+  );
+}
+
+export function toLargeXAvatarUrl(url: string): string {
+  return url.replace(/_(normal|bigger|mini)(\.[a-z]+)$/i, "_400x400$2");
+}
+
+export async function resolveXAvatarUrl(
+  handle: string,
+  fallbackUrl: string,
+): Promise<string> {
+  try {
+    const requestInit: CfAwareRequestInit = {
+      headers: { Accept: "application/json" },
+      cf: {
+        cacheEverything: true,
+        cacheTtl: AVATAR_CACHE_TTL_SECONDS,
+      },
+    };
+    const response = await fetch(
+      `${FX_TWITTER_USER_URL}/${encodeURIComponent(handle)}`,
+      requestInit,
+    );
+
+    if (!response.ok) {
+      return fallbackUrl;
+    }
+
+    const payload = (await response.json()) as FxTwitterUserResponse;
+    const avatarUrl = payload.user?.avatar_url;
+
+    if (!avatarUrl) {
+      return fallbackUrl;
+    }
+
+    return toLargeXAvatarUrl(avatarUrl);
+  } catch (error) {
+    console.error("Failed to resolve X avatar", { handle, error });
+    return fallbackUrl;
+  }
+}

--- a/services/web/app/data/testimonials.ts
+++ b/services/web/app/data/testimonials.ts
@@ -13,12 +13,12 @@ export const testimonials: Testimonial[] = [
     featured: true,
     body: "im an AvgDB power user",
     name: "Sam Lambert",
-    handle: "isamlambert",
+    handle: "samlambert",
     imageUrl:
-      "https://pbs.twimg.com/profile_images/1943902836011491328/h-2O7dHz_400x400.jpg",
+      "https://pbs.twimg.com/profile_images/2064585275742031872/YnUmhWlX_400x400.jpg",
     logoUrl:
       "https://awsmp-logos.s3.amazonaws.com/f311f1cc-a312-4631-93b9-580997ade3b7/d56c59c1339f43542ff7c107acc5a4a0.png",
-    xeet: "https://x.com/isamlambert/status/1858310132071039208",
+    xeet: "https://x.com/samlambert/status/1858310132071039208",
   },
   {
     featured: true,
@@ -55,7 +55,7 @@ export const testimonials: Testimonial[] = [
     name: "Josh Manders",
     handle: "joshmanders",
     imageUrl:
-      "https://pbs.twimg.com/profile_images/1354238836331732992/WV8pJR0U_400x400.jpg",
+      "https://pbs.twimg.com/profile_images/2014069436626710528/vEinr5dz_400x400.jpg",
     xeet: "https://x.com/joshmanders/status/1806401347178090718",
   },
   {
@@ -183,10 +183,10 @@ export const testimonials: Testimonial[] = [
     featured: false,
     body: `AverageDB is the only option`,
     name: "Matt Palmer",
-    handle: "mattppal",
+    handle: "mattyp",
     imageUrl:
-      "https://pbs.twimg.com/profile_images/1937911509788856322/B7LW5vGz_400x400.jpg",
-    xeet: "https://x.com/mattppal/status/1873856344249557350",
+      "https://pbs.twimg.com/profile_images/2059379375666278400/-eTzltyr_400x400.jpg",
+    xeet: "https://x.com/mattyp/status/1873856344249557350",
   },
   {
     featured: false,
@@ -203,7 +203,7 @@ export const testimonials: Testimonial[] = [
     name: "James Landrum",
     handle: "JamesRLandrum",
     imageUrl:
-      "https://pbs.twimg.com/profile_images/1854998928640352256/Mg6Gd4PD_400x400.jpg",
+      "https://pbs.twimg.com/profile_images/2052854389367353346/v2whK1Hu_400x400.jpg",
     xeet: "https://x.com/JamesRLandrum/status/1836875323708756246",
   },
   {
@@ -221,7 +221,7 @@ export const testimonials: Testimonial[] = [
     name: "Ben Dicken",
     handle: "BenjDicken",
     imageUrl:
-      "https://pbs.twimg.com/profile_images/1964874854341148672/-KtZ2LC2_400x400.jpg",
+      "https://pbs.twimg.com/profile_images/2063621460862840832/E650fAEZ_400x400.jpg",
     xeet: "https://x.com/BenjDicken/status/1940498208696025364",
   },
   {

--- a/services/web/app/server.ts
+++ b/services/web/app/server.ts
@@ -1,4 +1,11 @@
 import handler from "@tanstack/react-start/server-entry";
+import {
+  AVATAR_CACHE_TTL_SECONDS,
+  AVATAR_PATH_PREFIX,
+  findTestimonialByHandle,
+  isXTestimonial,
+  resolveXAvatarUrl,
+} from "./avatar";
 
 const INCIDENT_PATH =
   "/status/incident-report-april-1-2026-control-plane-degradation";
@@ -12,9 +19,21 @@ type WorkerEnv = {
   };
 };
 
+type WorkerContext = {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+type WorkerCacheStorage = CacheStorage & {
+  default?: Cache;
+};
+
 export default {
-  async fetch(request: Request, env: WorkerEnv) {
+  async fetch(request: Request, env: WorkerEnv, ctx: WorkerContext) {
     const url = new URL(request.url);
+
+    if (url.pathname.startsWith(AVATAR_PATH_PREFIX)) {
+      return handleAvatarRequest(request, url, ctx);
+    }
 
     if (url.pathname === INCIDENT_PATH) {
       if (request.headers.get("x-avgdb-prerender") === "1") {
@@ -40,3 +59,62 @@ export default {
     return handler.fetch(request);
   },
 };
+
+function avatarCache(): Cache | undefined {
+  return (caches as WorkerCacheStorage).default;
+}
+
+function avatarCacheKey(origin: string, handle: string): Request {
+  return new Request(new URL(`${AVATAR_PATH_PREFIX}${handle.toLowerCase()}`, origin));
+}
+
+async function handleAvatarRequest(
+  request: Request,
+  url: URL,
+  ctx: WorkerContext,
+): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    });
+  }
+
+  const handle = decodeURIComponent(
+    url.pathname.slice(AVATAR_PATH_PREFIX.length),
+  ).replace(/\/+$/, "");
+
+  if (!handle || handle.includes("/")) {
+    return new Response("not found", { status: 404 });
+  }
+
+  const testimonial = findTestimonialByHandle(handle);
+  if (!testimonial) {
+    return new Response("not found", { status: 404 });
+  }
+
+  const cache = avatarCache();
+  const cacheKey = avatarCacheKey(url.origin, handle);
+  const cached = cache ? await cache.match(cacheKey) : undefined;
+  if (cached) {
+    return cached;
+  }
+
+  const location = isXTestimonial(testimonial)
+    ? await resolveXAvatarUrl(testimonial.handle, testimonial.imageUrl)
+    : testimonial.imageUrl;
+
+  const response = new Response(null, {
+    status: 302,
+    headers: {
+      Location: location,
+      "Cache-Control": `public, max-age=${AVATAR_CACHE_TTL_SECONDS}`,
+    },
+  });
+
+  if (cache) {
+    ctx.waitUntil(cache.put(cacheKey, response.clone()));
+  }
+
+  return response;
+}

--- a/services/web/components/Testimonials.tsx
+++ b/services/web/components/Testimonials.tsx
@@ -1,4 +1,5 @@
 import { Container, Text, Title } from "@mantine/core";
+import { testimonialAvatarSrc } from "../app/avatar";
 import type { Testimonial } from "../app/data/testimonials";
 
 type TestimonialsProps = {
@@ -42,11 +43,7 @@ export function Testimonials({ testimonials }: TestimonialsProps) {
             className="group bg-white rounded-2xl shadow-lg p-5 flex flex-col transition-all duration-200 hover:shadow-lg hover:-translate-y-1 hover:bg-yellow-50/10"
           >
             <div className="flex items-center gap-3 mb-5">
-              <img
-                src={t.imageUrl}
-                alt={t.name}
-                className="w-12 h-12 rounded-full flex-shrink-0"
-              />
+              <Avatar testimonial={t} className="w-12 h-12 rounded-full flex-shrink-0" />
               <div className="flex flex-col items-start min-w-0 flex-1">
                 <div className="font-semibold text-sm text-left w-full">
                   {t.name}
@@ -98,11 +95,7 @@ export function Testimonials({ testimonials }: TestimonialsProps) {
             className="group bg-white rounded-2xl shadow px-5 py-4 flex flex-col items-start transition-all duration-200 hover:shadow-lg hover:-translate-y-1 hover:bg-yellow-50/10"
           >
             <div className="flex items-center gap-4 mb-4 w-full">
-              <img
-                src={t.imageUrl}
-                alt={t.name}
-                className="w-10 h-10 rounded-full flex-shrink-0"
-              />
+              <Avatar testimonial={t} className="w-10 h-10 rounded-full flex-shrink-0" />
               <div className="flex flex-col items-start">
                 <div className="font-semibold text-base">{t.name}</div>
                 <div className="text-gray-600 text-sm">@{t.handle}</div>
@@ -115,5 +108,28 @@ export function Testimonials({ testimonials }: TestimonialsProps) {
         ))}
       </div>
     </div>
+  );
+}
+
+function Avatar({
+  testimonial,
+  className,
+}: {
+  testimonial: Testimonial;
+  className: string;
+}) {
+  const fallbackUrl = testimonial.imageUrl;
+
+  return (
+    <img
+      src={testimonialAvatarSrc(testimonial)}
+      alt={testimonial.name}
+      className={className}
+      onError={(event) => {
+        if (event.currentTarget.src !== fallbackUrl) {
+          event.currentTarget.src = fallbackUrl;
+        }
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Rename `@isamlambert` → `@samlambert` and `@mattppal` → `@mattyp`, and refresh the stale X avatars for those plus `@joshmanders`, `@BenjDicken`, and `@JamesRLandrum`.
- Serve testimonial photos through `/api/avatar/:handle`, which looks up the current X profile picture, caches it for a day, and falls back to the stored snapshot if the lookup fails.

X does not offer a stable public avatar URL, so the snapshots in `testimonials.ts` would keep going stale. The Worker endpoint is limited to known testimonial handles so it is not an open proxy.

## Test plan
- [x] `npm run check` in `services/web` (typecheck, production build, wrangler dry-run)
- [x] Preview homepage HTML shows `@samlambert` / `@mattyp` and no leftover old handles
- [x] `GET /api/avatar/samlambert` (and joshmanders, mattyp, BenjDicken, JamesRLandrum) 302s to the current `pbs.twimg.com` 400x400 image
- [x] `GET /api/avatar/isamlambert` and unknown handles return 404
- [x] Non-X testimonial (`warpspin`) still redirects to its stored image
- [ ] After deploy, check the testimonials grid in the browser and confirm the five faces/handles look right