### PR TITLE
Stop wrangler deploy from wiping dashboard variables

### DIFF
--- a/services/web/wrangler.jsonc
+++ b/services/web/wrangler.jsonc
@@ -4,6 +4,8 @@
   "main": "./app/server.ts",
   "compatibility_date": "2026-08-15",
   "compatibility_flags": ["nodejs_compat"],
+  // Keep dashboard plaintext vars. wrangler deploy deletes them otherwise.
+  "keep_vars": true,
   "assets": {
     "binding": "ASSETS",
     "html_handling": "drop-trailing-slash",


### PR DESCRIPTION
`wrangler deploy` deletes plaintext dashboard variables unless `keep_vars` is set. Secrets are not deleted.

This only adds `keep_vars: true`. Runtime text variables stay in the Cloudflare dashboard.