### PR TITLE
Attach averagedatabase.com to the Railway-backed Worker

### DIFF
--- a/services/web/wrangler.jsonc
+++ b/services/web/wrangler.jsonc
@@ -6,6 +6,7 @@
   "compatibility_flags": ["nodejs_compat"],
   // Keep dashboard plaintext vars. wrangler deploy deletes them otherwise.
   "keep_vars": true,
+  "workers_dev": true,
   "vars": {
     "API_UPSTREAM": "https://averagedatabase-production.up.railway.app"
   },
@@ -18,6 +19,9 @@
       "/status/incident-report-april-1-2026-control-plane-degradation"
     ]
   },
+  "routes": [
+    { "pattern": "averagedatabase.com", "custom_domain": true }
+  ],
   "observability": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

- bind `averagedatabase.com` as a Custom Domain on `average-database-web`
- keep `workers.dev` enabled

Already deployed. Also deleted the leftover D1 database `average-database` and R2 bucket `average-database-uploads`. Left the unrelated `josevalerio` R2 bucket alone.