### PR TITLE
Serve the site from the Rust origin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.git
+**/node_modules
+**/dist
+**/target
+**/.wrangler
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22-bookworm AS web
+
+WORKDIR /web
+COPY services/web/package.json services/web/package-lock.json ./
+RUN npm ci
+COPY services/web ./
+RUN npm run build
+
+FROM rust:1-bookworm AS api
+
+WORKDIR /app
+COPY services/api/Cargo.toml services/api/Cargo.lock ./
+COPY services/api/src ./src
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=api /app/target/release/api /app/api
+COPY --from=api /app/src/avgdblogo.png /app/src/avgdblogo.png
+COPY --from=web /web/dist/client /app/static
+
+ENV STATIC_DIR=/app/static
+EXPOSE 8080
+CMD ["./api"]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ The only database built from the ground for the average developer.
 
 ### Hosting
 
-The marketing site is a prerendered TanStack Start app on Cloudflare. The
-Worker handles testimonial avatars and the April Fools incident redirect, then
-proxies `/api/*` to the Rust service on Railway. Keys and values live in an
-in-memory LRU cache. ASS files live in a Railway bucket.
+One Rust process on Railway is the origin. It serves the prerendered
+TanStack pages, live X avatar lookups, the April Fools redirect, and the
+API. Keys and values live in an in-memory LRU cache. ASS files live in a
+Railway bucket. Cache-Control is set per route so Cloudflare can orange-cloud
+the hostname and honor those headers.
 
 ### Support
 

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/services/api/Cargo.lock
+++ b/services/api/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +51,7 @@ dependencies = [
  "lru",
  "md5",
  "rand 0.8.6",
+ "regex",
  "reqwest",
  "rusty-s3",
  "serde",
@@ -1331,6 +1341,35 @@ checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.6.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -15,7 +15,8 @@ lopdf = "0.31.0"
 lru = "0.16.3"
 md5 = "0.7.0"
 rand = "0.8.5"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+regex = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusty-s3 = "0.7"
 serde = "1.0.203"
 serde_derive = "1.0.203"

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,3 +1,4 @@
 ## Blazingly Fast
 
 The database is an in-memory LRU cache. ASS files go in a Railway bucket.
+`STATIC_DIR` is the prerendered marketing site (default `/app/static`).

--- a/services/api/src/avatars.json
+++ b/services/api/src/avatars.json
@@ -1,0 +1,122 @@
+[
+  {
+    "handle": "samlambert",
+    "imageUrl": "https://pbs.twimg.com/profile_images/2064585275742031872/YnUmhWlX_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "kiwicopple",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1664343166630109202/xcBMGPSE_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "sorenbs",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1796990572965613569/aJIPcp4r_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "ctjlewis",
+    "imageUrl": "https://avatars.githubusercontent.com/u/1657236?v=4",
+    "live": true
+  },
+  {
+    "handle": "joshmanders",
+    "imageUrl": "https://pbs.twimg.com/profile_images/2014069436626710528/vEinr5dz_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "database_comedy",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1799057903808032768/opeDf-i__400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "AvgDatabaseCEO",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1779203735991758848/OipJE-5A_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "ImSh4yy",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1891066554634113025/RCPW1bUD_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "Sirupsen",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1066398389464555520/zockiRAy_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "nikitabase",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1585332383502372864/H1HKhMNg_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "cpdough",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1665443771914264577/n_Q0NT0i_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "grok",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1893219113717342208/Vgg2hEPa_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "swlkr",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1313488738446643201/p9wRf4HE_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "activenode",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1990726229880709120/3e_xseXq_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "mustafaakin",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1762800099506159616/wYQpT25__400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "supabase",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1822981431586439168/7xkKXRGQ_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "jamwt",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1616614464169840641/uQgxVHsf_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "mattyp",
+    "imageUrl": "https://pbs.twimg.com/profile_images/2059379375666278400/-eTzltyr_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "0xLukeKim",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1991912399977508864/HKIP_B5g_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "JamesRLandrum",
+    "imageUrl": "https://pbs.twimg.com/profile_images/2052854389367353346/v2whK1Hu_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "anuraggoel",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1632164169326936064/DYYVa-Rz_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "BenjDicken",
+    "imageUrl": "https://pbs.twimg.com/profile_images/2063621460862840832/E650fAEZ_400x400.jpg",
+    "live": true
+  },
+  {
+    "handle": "warpspin",
+    "imageUrl": "https://userdata-bcbe5a.stack.tryrelevance.com/files/public/4dc088f2dcfc-4e60-807e-353c334d4a5b/notebook-emoji-hackernews.png/ab752da5-181b-4c10-8a7d-31f3b14e1b00.png",
+    "live": false
+  },
+  {
+    "handle": "JacoBoogie",
+    "imageUrl": "https://pbs.twimg.com/profile_images/1756835267552669696/kXOJv6oP_400x400.jpg",
+    "live": true
+  }
+]

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,6 +1,7 @@
 extern crate serde_derive;
 
 mod ass;
+mod site;
 
 use rand::{distributions::Alphanumeric, Rng};
 use serde_derive::{Deserialize, Serialize};
@@ -16,7 +17,7 @@ use std::{collections::HashMap, ops::Deref};
 
 use axum::{
     extract::{DefaultBodyLimit, Extension, Multipart, Path as AxumPath, Query, Request},
-    http::StatusCode,
+    http::{header, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
     routing::{get, post},
@@ -425,12 +426,12 @@ async fn main() {
         Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(10000).unwrap())));
 
     let ass = ass::Ass::from_env();
+    let static_dir = site::static_dir();
 
     let api = Router::new()
-        // k8s check
         .route("/health", get(health))
-        .route("/", get(root))
         .route("/u-up", get(health2))
+        .route("/avatar/:handle", get(site::avatar))
         .route(
             "/SECRET_INTERNAL_ENDPOINT_DO_NOT_USE_OR_YOU_WILL_BE_FIRED_add_item",
             post(add_item).layer(ServiceBuilder::new().layer(middleware::from_fn(check_for_key))),
@@ -477,19 +478,26 @@ async fn main() {
             get(retrieve_file)
                 .layer(ServiceBuilder::new().layer(middleware::from_fn(check_for_key))),
         )
-        .route("/ass/:file_id", get(get_public_file));
+        .route("/ass/:file_id", get(get_public_file))
+        .layer(middleware::from_fn(default_api_cache))
+        .layer(middleware::from_fn(sorry_bud))
+        .layer(DefaultBodyLimit::max(10 * 1024 * 1024));
 
     let app = Router::new()
-        .merge(api.clone())
+        .route("/health", get(health))
+        .route(
+            "/status/incident-report-april-1-2026-control-plane-degradation",
+            get(site::incident),
+        )
         .nest("/api", api)
+        .fallback(site::static_file)
+        .with_state(static_dir)
         .layer(
             ServiceBuilder::new()
                 .layer(Extension(kv_cache.clone()))
                 .layer(Extension(auth_cache.clone()))
                 .layer(Extension(rate_limit_cache.clone()))
-                .layer(Extension(ass))
-                .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
-                .layer(middleware::from_fn(sorry_bud)),
+                .layer(Extension(ass)),
         );
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
@@ -499,8 +507,15 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn root() -> &'static str {
-    "Are you an idiot? Did you forget to look at the docs?"
+async fn default_api_cache(req: Request, next: Next) -> Response {
+    let mut response = next.run(req).await;
+    if !response.headers().contains_key(header::CACHE_CONTROL) {
+        response.headers_mut().insert(
+            header::CACHE_CONTROL,
+            header::HeaderValue::from_static("private, no-store"),
+        );
+    }
+    response
 }
 
 #[derive(Serialize)]
@@ -509,8 +524,11 @@ struct HealthResponse {
     brought_to_you_by: String,
 }
 
-async fn health() -> &'static str {
-    "Yeah"
+async fn health() -> impl IntoResponse {
+    (
+        [(header::CACHE_CONTROL, "private, no-store")],
+        "Yeah",
+    )
 }
 
 async fn health2() -> Response {
@@ -647,20 +665,14 @@ async fn add_item(
     (StatusCode::CREATED, Json(res)).into_response()
 }
 
-const SKIP_DELAY_PATH: [&str; 8] = [
-    "/health",
-    "/u-up",
-    "/",
-    "/gibs-key",
-    "/api/health",
-    "/api/u-up",
-    "/api/",
-    "/api/gibs-key",
-];
-
 async fn sorry_bud(req: Request, next: Next) -> Result<Response, Response> {
     let path = req.uri().path();
-    if SKIP_DELAY_PATH.contains(&path) {
+    if matches!(
+        path,
+        "/health" | "/u-up" | "/gibs-key" | "/api/health" | "/api/u-up" | "/api/gibs-key"
+    ) || path.starts_with("/api/avatar")
+        || path.starts_with("/avatar")
+    {
         return Ok(next.run(req).await);
     }
 
@@ -1566,6 +1578,7 @@ async fn get_public_file(
         return Response::builder()
             .status(StatusCode::OK)
             .header("Content-Type", file.content_type)
+            .header("Cache-Control", "public, max-age=3600")
             .header("X-Powered-By", "AvgDB ASS on a Railway bucket")
             .body(axum::body::Body::from(file.bytes))
             .unwrap()

--- a/services/api/src/site.rs
+++ b/services/api/src/site.rs
@@ -1,0 +1,246 @@
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderMap, StatusCode, Uri},
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use std::{
+    path::{Component, Path as FsPath, PathBuf},
+    sync::OnceLock,
+};
+
+const INCIDENT_PATH: &str = "/status/incident-report-april-1-2026-control-plane-degradation";
+const INCIDENT_REDIRECT_URL: &str = "https://www.youtube.com/watch?v=KnVu-qNEcrg";
+const AVATAR_CACHE: &str = "public, max-age=86400";
+const PAGE_CACHE: &str = "public, max-age=3600";
+const ASSET_CACHE: &str = "public, max-age=31536000, immutable";
+const FILE_CACHE: &str = "public, max-age=86400";
+const BOT_UA: &str =
+    "Twitterbot|facebookexternalhit|Slackbot|LinkedInBot|Discordbot|WhatsApp|Googlebot|bingbot|Applebot";
+
+#[derive(Clone, Deserialize)]
+struct AvatarEntry {
+    handle: String,
+    #[serde(rename = "imageUrl")]
+    image_url: String,
+    live: bool,
+}
+
+#[derive(Deserialize)]
+struct FxUser {
+    avatar_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct FxTwitterUserResponse {
+    user: Option<FxUser>,
+}
+
+pub fn static_dir() -> PathBuf {
+    std::env::var("STATIC_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/app/static"))
+}
+
+pub async fn avatar(Path(handle): Path<String>) -> Response {
+    let handle = handle.trim_matches('/').to_string();
+    if handle.is_empty() || handle.contains('/') {
+        return not_found();
+    }
+
+    let Some(entry) = find_avatar(&handle) else {
+        return not_found();
+    };
+
+    let location = if entry.live {
+        resolve_x_avatar(&entry.handle, &entry.image_url).await
+    } else {
+        entry.image_url.clone()
+    };
+
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, location)
+        .header(header::CACHE_CONTROL, AVATAR_CACHE)
+        .body(axum::body::Body::empty())
+        .unwrap()
+}
+
+pub async fn incident(headers: HeaderMap, State(dir): State<PathBuf>) -> Response {
+    let user_agent = headers
+        .get(header::USER_AGENT)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+
+    if !is_bot(user_agent) {
+        return Response::builder()
+            .status(StatusCode::FOUND)
+            .header(header::LOCATION, INCIDENT_REDIRECT_URL)
+            .header(header::CACHE_CONTROL, "private, no-store")
+            .header(header::VARY, "User-Agent")
+            .body(axum::body::Body::empty())
+            .unwrap();
+    }
+
+    serve_file(
+        dir.join(INCIDENT_PATH.trim_start_matches('/')).join("index.html"),
+        PAGE_CACHE,
+        &[
+            (header::VARY, "User-Agent"),
+        ],
+    )
+    .await
+}
+
+pub async fn static_file(State(dir): State<PathBuf>, uri: Uri) -> Response {
+    let requested = uri.path();
+    if requested == INCIDENT_PATH || requested == format!("{INCIDENT_PATH}/") {
+        return not_found();
+    }
+
+    let Some(path) = resolve_static(&dir, requested) else {
+        return serve_file(dir.join("404.html"), PAGE_CACHE, &[]).await;
+    };
+
+    serve_file(path, cache_control_for(requested), &[]).await
+}
+
+fn cache_control_for(path: &str) -> &'static str {
+    if path.starts_with("/assets/") {
+        ASSET_CACHE
+    } else if path.ends_with(".html") || path.ends_with('/') || !path.rsplit('/').next().unwrap_or("").contains('.') {
+        PAGE_CACHE
+    } else {
+        FILE_CACHE
+    }
+}
+
+fn resolve_static(dir: &FsPath, request_path: &str) -> Option<PathBuf> {
+    let relative = request_path.trim_start_matches('/');
+    if relative.contains('\0') {
+        return None;
+    }
+
+    let mut joined = dir.to_path_buf();
+    if !relative.is_empty() {
+        for component in FsPath::new(relative).components() {
+            match component {
+                Component::Normal(part) => joined.push(part),
+                _ => return None,
+            }
+        }
+    }
+
+    if joined.is_file() {
+        return Some(joined);
+    }
+    let index = joined.join("index.html");
+    if index.is_file() {
+        return Some(index);
+    }
+    None
+}
+
+async fn serve_file(path: PathBuf, cache: &'static str, extra: &[(header::HeaderName, &str)]) -> Response {
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(bytes) => bytes,
+        Err(_) => return not_found(),
+    };
+
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type(&path))
+        .header(header::CACHE_CONTROL, cache);
+
+    for (name, value) in extra {
+        builder = builder.header(name, *value);
+    }
+
+    builder.body(axum::body::Body::from(bytes)).unwrap()
+}
+
+fn content_type(path: &FsPath) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "html" => "text/html; charset=utf-8",
+        "js" => "text/javascript; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "json" | "webmanifest" => "application/json",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "ico" => "image/x-icon",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        "txt" => "text/plain; charset=utf-8",
+        "xml" => "application/xml",
+        "map" => "application/json",
+        _ => "application/octet-stream",
+    }
+}
+
+fn not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        [(header::CACHE_CONTROL, "private, no-store")],
+        "not found",
+    )
+        .into_response()
+}
+
+fn avatars() -> &'static [AvatarEntry] {
+    static AVATARS: OnceLock<Vec<AvatarEntry>> = OnceLock::new();
+    AVATARS.get_or_init(|| {
+        serde_json::from_str(include_str!("avatars.json")).expect("avatars.json")
+    })
+}
+
+fn find_avatar(handle: &str) -> Option<&'static AvatarEntry> {
+    avatars()
+        .iter()
+        .find(|entry| entry.handle.eq_ignore_ascii_case(handle))
+}
+
+async fn resolve_x_avatar(handle: &str, fallback: &str) -> String {
+    let url = format!("https://api.fxtwitter.com/{}", handle);
+    let response = reqwest::Client::new()
+        .get(url)
+        .header(header::ACCEPT, "application/json")
+        .send()
+        .await;
+
+    let Ok(response) = response else {
+        return fallback.to_string();
+    };
+    if !response.status().is_success() {
+        return fallback.to_string();
+    }
+
+    let Ok(payload) = response.json::<FxTwitterUserResponse>().await else {
+        return fallback.to_string();
+    };
+
+    payload
+        .user
+        .and_then(|user| user.avatar_url)
+        .map(|avatar| to_large_x_avatar_url(&avatar))
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn to_large_x_avatar_url(url: &str) -> String {
+    let re = regex::Regex::new(r"_(normal|bigger|mini)(\.[A-Za-z]+)$").unwrap();
+    re.replace(url, "_400x400$2").into_owned()
+}
+
+fn is_bot(user_agent: &str) -> bool {
+    static PATTERN: OnceLock<regex::Regex> = OnceLock::new();
+    let pattern = PATTERN.get_or_init(|| regex::Regex::new(BOT_UA).expect("bot ua"));
+    pattern.is_match(user_agent)
+}

--- a/services/web/README.md
+++ b/services/web/README.md
@@ -1,20 +1,10 @@
 # Average Database web
 
-The marketing site is a TanStack Start application. Public pages are
-prerendered to static HTML and served from Cloudflare. That is the right host
-for a mostly-static site: more PoPs than Railway CDN.
-
-The Worker only runs for:
-
-- `/api/avatar/:handle`
-- `/api/*`, proxied to the Rust API on Railway
-- the April Fools incident redirect
-
-Set `API_UPSTREAM` to the Railway API origin.
+TanStack Start prerenders the marketing pages into `dist/client`. The Rust
+origin serves those files. `npm run build` is a compile step, not a server.
 
 ```bash
 npm install
 npm run typecheck
 npm run build
-npm run preview
 ```


### PR DESCRIPTION
## Summary

- one Railway process is the origin: prerendered TanStack pages, \`/api/*\`, \`/api/avatar/:handle\`, and the incident redirect
- Cache-Control is set in Rust: HTML 1h, hashed assets 1y immutable, API \`private, no-store\`, avatars 1d, public ASS 1h
- live avatar lookup still falls back to the stored snapshot so faces do not 404

## Railway / DNS

Railway is already serving this at https://averagedatabase-production.up.railway.app

To put Cloudflare in front as a cache:

1. Point \`averagedatabase.com\` at \`msb324xj.up.railway.app\` (CNAME, orange cloud)
2. Remove the Worker custom domain so Cloudflare stops treating the Worker as origin
3. Cache everything at the edge and let origin headers decide what is stored

The Worker can stay until DNS is flipped. After that it is unused.