### PR TITLE
Point Wrangler at the Worker that owns averagedatabase.com

### DIFF
--- a/services/web/wrangler.jsonc
+++ b/services/web/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
-  "name": "average-database-web",
+  "name": "averagedatabase",
   "main": "./app/server.ts",
   "compatibility_date": "2026-08-15",
   "compatibility_flags": ["nodejs_compat"],


### PR DESCRIPTION
There were two Workers:

- \`averagedatabase\` — created Aug 16, custom domain \`averagedatabase.com\`
- \`average-database-web\` — created by later wrangler deploys, no domain

Deleted \`average-database-web\`. Config name is now \`averagedatabase\` so deploys hit the live Worker. D1 and R2 stay attached there.